### PR TITLE
feat: shared client infrastructure (Vite config factory, buildResources DSL, jest base)

### DIFF
--- a/components/app/__tests__/buildResources.spec.jsx
+++ b/components/app/__tests__/buildResources.spec.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { buildResources } from '../buildResources';
 
 jest.mock('react-admin', () => ({

--- a/components/app/__tests__/buildResources.spec.jsx
+++ b/components/app/__tests__/buildResources.spec.jsx
@@ -4,13 +4,17 @@ import { buildResources } from '../buildResources';
 jest.mock('react-admin', () => ({
   Resource: 'Resource',
 }));
+jest.mock('@shared/utils/filtersUtil', () => ({
+  filterArrayByParams: (items, params) =>
+    items.map(item => typeof item === 'function' ? item(params) : item).filter(item => item),
+}));
 
 describe('buildResources', () => {
   const mockConfig = { list: () => null, edit: () => null };
 
   const definitions = [
     { name: 'always', config: mockConfig, icon: null, menuGroup: 'data' },
-    { name: 'admin-only', config: mockConfig, icon: null, menuGroup: 'admin', condition: p => p.isAdmin },
+    p => p.isAdmin && { name: 'admin-only', config: mockConfig, icon: null, menuGroup: 'admin' },
     { name: 'no-config', icon: null, menuGroup: 'data' },
   ];
 

--- a/components/app/__tests__/buildResources.spec.jsx
+++ b/components/app/__tests__/buildResources.spec.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { buildResources } from '../buildResources';
+
+jest.mock('react-admin', () => ({
+  Resource: 'Resource',
+}));
+
+describe('buildResources', () => {
+  const mockConfig = { list: () => null, edit: () => null };
+
+  const definitions = [
+    { name: 'always', config: mockConfig, icon: null, menuGroup: 'data' },
+    { name: 'admin-only', config: mockConfig, icon: null, menuGroup: 'admin', condition: p => p.isAdmin },
+    { name: 'no-config', icon: null, menuGroup: 'data' },
+  ];
+
+  it('filters out resources whose condition returns false', () => {
+    const result = buildResources(definitions, { isAdmin: false });
+    expect(result).toHaveLength(2);
+    expect(result.map(r => r.props.name)).not.toContain('admin-only');
+  });
+
+  it('includes all resources when condition returns true', () => {
+    const result = buildResources(definitions, { isAdmin: true });
+    expect(result).toHaveLength(3);
+  });
+
+  it('renders correct resource names', () => {
+    const result = buildResources(definitions, { isAdmin: true });
+    expect(result.map(r => r.props.name)).toEqual(['always', 'admin-only', 'no-config']);
+  });
+
+  it('spreads config onto the Resource', () => {
+    const result = buildResources([{ name: 'foo', config: mockConfig, icon: null, menuGroup: 'data' }], {});
+    expect(result[0].props.list).toBe(mockConfig.list);
+  });
+
+  it('handles missing config gracefully (empty Resource)', () => {
+    const result = buildResources([{ name: 'bare', icon: null, menuGroup: 'data' }], {});
+    expect(result[0].props.name).toBe('bare');
+    expect(result[0].props.list).toBeUndefined();
+  });
+});

--- a/components/app/buildResources.jsx
+++ b/components/app/buildResources.jsx
@@ -1,16 +1,20 @@
 import React from 'react';
 import { Resource } from 'react-admin';
+import { filterArrayByParams } from '@shared/utils/filtersUtil';
 
 /**
  * Converts a declarative resource definitions array into React-Admin <Resource> elements.
  *
- * @param {Array<{ name, config, icon, menuGroup, label?, hide?, condition? }>} definitions
+ * Each item can be:
+ *  - A plain object `{ name, config, icon, menuGroup, label?, hide? }`
+ *  - A function `permissions => object | null` (return falsy to exclude)
+ *
+ * @param {Array<object|Function>} definitions
  * @param {object} permissions — the permissions object from React Admin
  * @returns {JSX.Element[]}
  */
 export function buildResources(definitions, permissions) {
-  return definitions
-    .filter(({ condition }) => !condition || condition(permissions))
+  return filterArrayByParams(definitions, permissions)
     .map(({ name, config, icon, menuGroup, hide, label }) => (
       <Resource
         key={name}

--- a/components/app/buildResources.jsx
+++ b/components/app/buildResources.jsx
@@ -20,7 +20,12 @@ export function buildResources(definitions, permissions) {
                 {...(config || {})}
                 name={name}
                 icon={icon}
-                options={{ ...(config && config.options ? config.options : {}), menuGroup, hide, label }}
+                options={{
+                    ...(config && config.options ? config.options : {}),
+                    ...(menuGroup !== undefined && { menuGroup }),
+                    ...(hide !== undefined && { hide }),
+                    ...(label !== undefined && { label }),
+                }}
             />
         ));
 }

--- a/components/app/buildResources.jsx
+++ b/components/app/buildResources.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Resource } from 'react-admin';
+
+/**
+ * Converts a declarative resource definitions array into React-Admin <Resource> elements.
+ *
+ * @param {Array<{ name, config, icon, menuGroup, label?, hide?, condition? }>} definitions
+ * @param {object} permissions — the permissions object from React Admin
+ * @returns {JSX.Element[]}
+ */
+export function buildResources(definitions, permissions) {
+  return definitions
+    .filter(({ condition }) => !condition || condition(permissions))
+    .map(({ name, config, icon, menuGroup, hide, label }) => (
+      <Resource
+        key={name}
+        name={name}
+        {...(config || {})}
+        icon={icon}
+        options={{ menuGroup, hide, label }}
+      />
+    ));
+}

--- a/components/app/buildResources.jsx
+++ b/components/app/buildResources.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Resource } from 'react-admin';
 import { filterArrayByParams } from '@shared/utils/filtersUtil';
 
@@ -14,14 +13,14 @@ import { filterArrayByParams } from '@shared/utils/filtersUtil';
  * @returns {JSX.Element[]}
  */
 export function buildResources(definitions, permissions) {
-  return filterArrayByParams(definitions, permissions)
-    .map(({ name, config, icon, menuGroup, hide, label }) => (
-      <Resource
-        key={name}
-        name={name}
-        {...(config || {})}
-        icon={icon}
-        options={{ menuGroup, hide, label }}
-      />
-    ));
+    return filterArrayByParams(definitions, permissions)
+        .map(({ name, config, icon, menuGroup, hide, label }) => (
+            <Resource
+                key={name}
+                {...(config || {})}
+                name={name}
+                icon={icon}
+                options={{ ...(config && config.options ? config.options : {}), menuGroup, hide, label }}
+            />
+        ));
 }

--- a/config/createViteConfig.js
+++ b/config/createViteConfig.js
@@ -19,6 +19,9 @@ export function createViteConfig(options = {}) {
     return defineConfig({
       envPrefix: 'REACT_APP',
       plugins: [react()],
+      // Use a project-local cache dir so multiple projects sharing the same
+      // node_modules directory don't overwrite each other's Vite pre-bundle cache.
+      cacheDir: path.resolve(process.cwd(), '.vite-cache'),
       server: {
         host: '0.0.0.0',
         port,

--- a/config/createViteConfig.js
+++ b/config/createViteConfig.js
@@ -13,8 +13,9 @@ import path from 'path';
 export function createViteConfig(options = {}) {
   const { apiUrlEnvKey = 'REACT_APP_API_URL' } = options;
 
-  return ({ mode }) => {
+  return ({ mode, command }) => {
     const port = Number(process.env.PORT || 3000);
+    const nodeEnv = command === 'build' ? 'production' : 'development';
 
     return defineConfig({
       envPrefix: 'REACT_APP',
@@ -32,8 +33,8 @@ export function createViteConfig(options = {}) {
         },
       },
       define: {
-        'process.env.NODE_ENV': `"${mode}"`,
-        [`process.env.${apiUrlEnvKey}`]: `"${process.env[apiUrlEnvKey] ?? ''}"`,
+        'process.env.NODE_ENV': JSON.stringify(nodeEnv),
+        [`process.env.${apiUrlEnvKey}`]: JSON.stringify(process.env[apiUrlEnvKey] ?? ''),
       },
       resolve: {
         alias: {

--- a/config/createViteConfig.js
+++ b/config/createViteConfig.js
@@ -4,8 +4,8 @@ import path from 'path';
 
 /**
  * Creates a standard Vite config for NRA client applications.
- * Port and HMR port are read from environment variables (PORT, HMR_PORT)
- * so each project can be assigned a unique block in docker-compose.override.yml.
+ * Port is read from the PORT environment variable so each project
+ * can be assigned a unique port in docker-compose.override.yml.
  *
  * @param {object} [options]
  * @param {string} [options.apiUrlEnvKey='REACT_APP_API_URL'] - env key for the API URL

--- a/config/createViteConfig.js
+++ b/config/createViteConfig.js
@@ -15,7 +15,6 @@ export function createViteConfig(options = {}) {
 
   return ({ mode }) => {
     const port = Number(process.env.PORT || 3000);
-    const hmrPort = Number(process.env.HMR_PORT || port);
 
     return defineConfig({
       envPrefix: 'REACT_APP',
@@ -25,10 +24,8 @@ export function createViteConfig(options = {}) {
         port,
         hmr: {
           overlay: true,
-          port: hmrPort,
-          timeout: 1000,
-          clientPort: hmrPort,
-          host: 'localhost',
+          // In Vite 2.x the HMR WebSocket shares the main HTTP server port.
+          // Setting a separate hmr.port/clientPort breaks the WS connection.
         },
       },
       define: {

--- a/config/createViteConfig.js
+++ b/config/createViteConfig.js
@@ -13,7 +13,7 @@ import path from 'path';
 export function createViteConfig(options = {}) {
   const { apiUrlEnvKey = 'REACT_APP_API_URL' } = options;
 
-  return ({ mode, command }) => {
+  return ({ command }) => {
     const port = Number(process.env.PORT || 3000);
     const nodeEnv = command === 'build' ? 'production' : 'development';
 

--- a/config/createViteConfig.js
+++ b/config/createViteConfig.js
@@ -1,0 +1,54 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+/**
+ * Creates a standard Vite config for NRA client applications.
+ * Port and HMR port are read from environment variables (PORT, HMR_PORT)
+ * so each project can be assigned a unique block in docker-compose.override.yml.
+ *
+ * @param {object} [options]
+ * @param {string} [options.apiUrlEnvKey='REACT_APP_API_URL'] - env key for the API URL
+ */
+export function createViteConfig(options = {}) {
+  const { apiUrlEnvKey = 'REACT_APP_API_URL' } = options;
+
+  return ({ mode }) => {
+    const port = Number(process.env.PORT || 3000);
+    const hmrPort = Number(process.env.HMR_PORT || port);
+
+    return defineConfig({
+      envPrefix: 'REACT_APP',
+      plugins: [react()],
+      server: {
+        host: '0.0.0.0',
+        port,
+        hmr: {
+          overlay: true,
+          port: hmrPort,
+          timeout: 1000,
+          clientPort: hmrPort,
+          host: 'localhost',
+        },
+      },
+      define: {
+        'process.env.NODE_ENV': `"${mode}"`,
+        [`process.env.${apiUrlEnvKey}`]: `"${process.env[apiUrlEnvKey] ?? ''}"`,
+      },
+      resolve: {
+        alias: {
+          '@shared': path.resolve(process.cwd(), './shared'),
+          src: path.resolve(process.cwd(), './src'),
+        },
+      },
+      build: {
+        rollupOptions: {
+          onwarn(warning, warn) {
+            if (warning.code === 'MODULE_LEVEL_DIRECTIVE') return;
+            warn(warning);
+          },
+        },
+      },
+    });
+  };
+}

--- a/config/jest.base.js
+++ b/config/jest.base.js
@@ -1,8 +1,7 @@
 module.exports = {
   moduleNameMapper: {
-    'src/(.*)': '<rootDir>/src/$1',
-    '@shared/(.*)': '<rootDir>/shared/$1',
+    '^src/(.*)$': '<rootDir>/src/$1',
+    '^@shared/(.*)$': '<rootDir>/shared/$1',
   },
   testEnvironment: 'jsdom',
-  setupFilesAfterEnv: ['./src/setupTests.js'],
 };

--- a/config/jest.base.js
+++ b/config/jest.base.js
@@ -1,0 +1,8 @@
+module.exports = {
+  moduleNameMapper: {
+    'src/(.*)': '<rootDir>/src/$1',
+    '@shared/(.*)': '<rootDir>/shared/$1',
+  },
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['./src/setupTests.js'],
+};


### PR DESCRIPTION
## Summary

Adds shared client infrastructure to standardize configuration and resource building across all NRA projects.

## Changes

- `feat: add jest.base.js shared base config` — single jest config reused by all projects
- `feat: add buildResources DSL with tests` — declarative DSL for defining React-Admin resources
- `feat: add createViteConfig factory for standardized Vite configuration` — Vite config factory with sensible defaults, project-local cacheDir, correct HMR setup
- `refactor: use filterArrayByParams in buildResources` — cleaner resource filtering
- `fix: remove separate HMR port` — Vite 2.x WS shares the main HTTP server port, separate hmr.port broke WS connections
- `fix: use project-local cacheDir` — avoids Vite cache conflicts when node_modules are shared between projects
- `refactor: remove Vite proxy support (VITE_PROXY_TARGET)` — direct API URL via env is simpler and works with the multi-repo setup