### PR TITLE
Add CommonYearField, CommonYearInput, and CommonYearInputFilter components

### DIFF
--- a/components/fields/CommonYear.jsx
+++ b/components/fields/CommonYear.jsx
@@ -1,0 +1,20 @@
+import { SelectField } from 'react-admin';
+import { yearChoices, defaultYearFilter } from '@shared/utils/yearFilter';
+import CommonAutocompleteInput from './CommonAutocompleteInput';
+
+export const CommonYearField = (props) => (
+    <SelectField source="year" choices={yearChoices} {...props} />
+);
+
+export const CommonYearInput = (props) => (
+    <CommonAutocompleteInput
+        source="year"
+        choices={yearChoices}
+        defaultValue={defaultYearFilter.year}
+        {...props}
+    />
+);
+
+export const CommonYearInputFilter = (props) => (
+    <CommonYearInput alwaysOn {...props} />
+);


### PR DESCRIPTION
Adds three shared year components to `components/fields/CommonYear.jsx`:

- `CommonYearField` — wraps `SelectField` with `source="year"` and `yearChoices`
- `CommonYearInput` — wraps `CommonAutocompleteInput` with `source="year"`, `yearChoices`, and `defaultYearFilter.year`
- `CommonYearInputFilter` — same as `CommonYearInput` with `alwaysOn`

## Usage

```jsx
import { CommonYearField, CommonYearInput, CommonYearInputFilter } from '@shared/components/fields/CommonYear';

// In a List/Show:
<CommonYearField />

// In Edit/Create forms:
<CommonYearInput />

// In List filters:
<CommonYearInputFilter />
```

All three default to `source="year"` and use `yearChoices` / `defaultYearFilter` from `@shared/utils/yearFilter`.

After merging, bump the `nra-client` submodule pointer in each project repo and replace the verbose inline year patterns with these components.