### PR TITLE
feat: redesign yemot simulator as chat-style UX

### DIFF
--- a/components/views/YemotSimulator.jsx
+++ b/components/views/YemotSimulator.jsx
@@ -276,37 +276,41 @@ const SimulatorToolbar = ({ phase, params, onNewCall }) => (
     </Toolbar>
 );
 
-const CallInputs = ({ phase, params, activeLabel }) => (
-    <>
-        <TextInput source="ApiCallId" validate={required()} readOnly sx={{ display: 'none' }} />
-        <TextInput source="ApiExtension" validate={required()} readOnly sx={{ display: 'none' }} />
-        <TextInput
-            source="ApiDID"
-            label="מספר מערכת"
-            validate={required()}
-            sx={{ display: phase === 'setup' ? undefined : 'none' }}
-        />
-        <TextInput
-            source="ApiPhone"
-            label="מאת מס׳ טלפון"
-            validate={required()}
-            sx={{ display: phase === 'setup' ? undefined : 'none' }}
-        />
-        <TextInput
-            source="ApiEnterID"
-            label="מספר זיהוי"
-            sx={{ display: phase === 'setup' ? undefined : 'none' }}
-        />
-        {phase === 'in-call' && params.map(param => (
+const CallInputs = ({ phase, params, activeLabel }) => {
+    const translate = useTranslate();
+
+    return (
+        <>
+            <TextInput source="ApiCallId" validate={required()} readOnly sx={{ display: 'none' }} />
+            <TextInput source="ApiExtension" validate={required()} readOnly sx={{ display: 'none' }} />
             <TextInput
-                source={param}
-                key={param}
-                label={activeLabel || undefined}
+                source="ApiDID"
+                label="מספר מערכת"
                 validate={required()}
+                sx={{ display: phase === 'setup' ? undefined : 'none' }}
             />
-        ))}
-    </>
-);
+            <TextInput
+                source="ApiPhone"
+                label="מאת מס׳ טלפון"
+                validate={required()}
+                sx={{ display: phase === 'setup' ? undefined : 'none' }}
+            />
+            <TextInput
+                source="ApiEnterID"
+                label="מספר זיהוי"
+                sx={{ display: phase === 'setup' ? undefined : 'none' }}
+            />
+            {phase === 'in-call' && params.map(param => (
+                <TextInput
+                    source={param}
+                    key={param}
+                    label={activeLabel || translate('ra.yemot_simulator.answer_label')}
+                    validate={required()}
+                />
+            ))}
+        </>
+    );
+};
 
 const HangupMessage = ({ phase }) => {
     const translate = useTranslate();
@@ -329,10 +333,16 @@ const YemotSimulator = () => {
     const [phase, setPhase] = useState('setup');
     const [setupValues, setSetupValues] = useState(null);
     const notify = useNotify();
+    const sessionRef = useRef(0);
 
     const { mutate } = useMutation({
         mutationFn: (body) => dataProvider.simulateYemotCall(body),
-        onSuccess: (data, variables) => {
+        onMutate: () => ({ session: sessionRef.current }),
+        onSuccess: (data, variables, context) => {
+            if (context.session !== sessionRef.current) {
+                return;
+            }
+
             const parsedData = parseYemotResponse(data.body);
 
             if (phase === 'setup') {
@@ -359,7 +369,10 @@ const YemotSimulator = () => {
 
             notify('ra.yemot_simulator.step_success', { type: 'info' });
         },
-        onError: () => {
+        onError: (error, variables, context) => {
+            if (context.session !== sessionRef.current) {
+                return;
+            }
             notify('ra.message.error', { type: 'error' });
         }
     });
@@ -381,6 +394,7 @@ const YemotSimulator = () => {
     }, [mutate, params]);
 
     const handleNewCall = useCallback(() => {
+        sessionRef.current += 1;
         setHistory([]);
         setParams([]);
         setPhase('setup');

--- a/components/views/YemotSimulator.jsx
+++ b/components/views/YemotSimulator.jsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, Chip, Box, Paper, Typography } from '@mui/material';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { SimpleForm, TextInput, Title, useDataProvider, useNotify, useTranslate, Toolbar, SaveButton, RefreshButton } from 'react-admin';
+import { SimpleForm, TextInput, Title, useDataProvider, useGetIdentity, useNotify, useTranslate, Toolbar, SaveButton, RefreshButton } from 'react-admin';
 import { useMutation } from '@tanstack/react-query';
 import { useFormContext } from 'react-hook-form';
 import CallEndIcon from '@mui/icons-material/CallEnd'
@@ -183,6 +183,22 @@ const ConversationTranscript = ({ history }) => {
     );
 };
 
+const PhonePrefill = ({ phase }) => {
+    const { identity } = useGetIdentity();
+    const form = useFormContext();
+
+    useEffect(() => {
+        if (phase !== 'setup' || !identity?.phoneNumber) {
+            return;
+        }
+        if (!form.getValues('ApiPhone')) {
+            form.setValue('ApiPhone', identity.phoneNumber);
+        }
+    }, [phase, identity?.phoneNumber, form]);
+
+    return null;
+};
+
 const CallSetupSummary = ({ values }) => {
     if (!values) return null;
 
@@ -227,12 +243,17 @@ const HangupButton = ({ params, phase, handleSubmit, ...props }) => {
 };
 
 const NewCallButton = ({ onNewCall, ...props }) => {
+    const { identity } = useGetIdentity();
     const form = useFormContext();
 
     const handleClick = useCallback(() => {
-        form.reset({ ...DEFAULT_VALUES, ApiCallId: String(Math.random()).slice(2) });
+        form.reset({
+            ...DEFAULT_VALUES,
+            ApiCallId: String(Math.random()).slice(2),
+            ApiPhone: identity?.phoneNumber || DEFAULT_VALUES.ApiPhone,
+        });
         onNewCall();
-    }, [form, onNewCall]);
+    }, [form, identity?.phoneNumber, onNewCall]);
 
     return (
         <RefreshButton
@@ -310,6 +331,7 @@ const HangupMessage = ({ phase }) => {
 // Main Component
 const YemotSimulator = () => {
     const dataProvider = useDataProvider();
+    const { identity } = useGetIdentity();
     const [history, setHistory] = useState([]);
     const [params, setParams] = useState([]);
     const [phase, setPhase] = useState('setup');
@@ -374,6 +396,10 @@ const YemotSimulator = () => {
     }, []);
 
     const activeLabel = history.length ? getPromptText(history[history.length - 1].prompt) : '';
+    const initialDefaultValues = {
+        ...DEFAULT_VALUES,
+        ApiPhone: identity?.phoneNumber || DEFAULT_VALUES.ApiPhone,
+    };
 
     return (
         <Card>
@@ -381,7 +407,7 @@ const YemotSimulator = () => {
             <CardContent>
                 <SimpleForm
                     onSubmit={handleSubmit}
-                    defaultValues={DEFAULT_VALUES}
+                    defaultValues={initialDefaultValues}
                     toolbar={
                         <SimulatorToolbar
                             phase={phase}
@@ -391,6 +417,7 @@ const YemotSimulator = () => {
                         />
                     }
                 >
+                    <PhonePrefill phase={phase} />
                     <CallSetupSummary values={phase !== 'setup' ? setupValues : null} />
                     <ConversationTranscript history={history} />
                     <CallInputs phase={phase} params={params} activeLabel={activeLabel} />

--- a/components/views/YemotSimulator.jsx
+++ b/components/views/YemotSimulator.jsx
@@ -156,7 +156,7 @@ const ConversationTranscript = ({ history }) => {
 
     useEffect(() => {
         bottomRef.current?.scrollIntoView({ block: 'nearest' });
-    }, [history.length]);
+    }, [history]);
 
     if (!history.length) {
         return null;
@@ -213,19 +213,12 @@ const CallSetupSummary = ({ values }) => {
     );
 };
 
-const HangupButton = ({ params, phase, handleSubmit, ...props }) => {
+const HangupButton = ({ params, phase, ...props }) => {
     const form = useFormContext();
 
     const handleClick = useCallback(() => {
         form.setValue('hangup', 'yes');
     }, [form]);
-
-    useEffect(() => {
-        if (phase === 'hangup') {
-            form.setValue('hangup', 'yes');
-            form.handleSubmit(handleSubmit);
-        }
-    }, [phase, form, handleSubmit]);
 
     if (phase === 'hangup') {
         return null;
@@ -266,7 +259,7 @@ const NewCallButton = ({ onNewCall, ...props }) => {
     );
 };
 
-const SimulatorToolbar = ({ phase, params, handleSubmit, onNewCall }) => (
+const SimulatorToolbar = ({ phase, params, onNewCall }) => (
     <Toolbar>
         <SaveButton
             label={phase === 'setup' ? 'ra.yemot_simulator.start_call' : 'ra.yemot_simulator.send'}
@@ -277,7 +270,6 @@ const SimulatorToolbar = ({ phase, params, handleSubmit, onNewCall }) => (
         <HangupButton
             params={params}
             phase={phase}
-            handleSubmit={handleSubmit}
             alwaysEnable={true}
             formNoValidate
         />
@@ -412,7 +404,6 @@ const YemotSimulator = () => {
                         <SimulatorToolbar
                             phase={phase}
                             params={params}
-                            handleSubmit={handleSubmit}
                             onNewCall={handleNewCall}
                         />
                     }

--- a/components/views/YemotSimulator.jsx
+++ b/components/views/YemotSimulator.jsx
@@ -1,6 +1,6 @@
-import { Card, CardContent, Chip, Box } from '@mui/material';
-import { useCallback, useEffect, useState } from 'react';
-import { SimpleForm, TextInput, Title, useDataProvider, useNotify, Toolbar, SaveButton, RefreshButton } from 'react-admin';
+import { Card, CardContent, Chip, Box, Paper, Typography } from '@mui/material';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { SimpleForm, TextInput, Title, useDataProvider, useNotify, useTranslate, Toolbar, SaveButton, RefreshButton } from 'react-admin';
 import { useMutation } from '@tanstack/react-query';
 import { useFormContext } from 'react-hook-form';
 import CallEndIcon from '@mui/icons-material/CallEnd'
@@ -32,14 +32,14 @@ const parseResponseLine = (line) => {
         const [, text] = textMatch;
         return { type: 'text', content: text };
     }
-    
+
     // Check for file messages
     const fileMatch = REGEX_PATTERNS.FILE.exec(line);
     if (fileMatch) {
         const [, filename] = fileMatch;
         return { type: 'file', content: filename };
     }
-    
+
     return null;
 };
 
@@ -57,14 +57,14 @@ const parseParameterFromLine = (line) => {
 const parseYemotResponse = (responseBody) => {
     const parsedData = { lines: [], param: '', hangup: false };
     const lines = responseBody.split('&');
-    
+
     for (const line of lines) {
-        
+
         const messageResult = parseResponseLine(line);
         if (messageResult) {
             parsedData.lines.push(messageResult);
         }
-        
+
         const param = parseParameterFromLine(line);
         if (param) {
             parsedData.param = param;
@@ -74,22 +74,26 @@ const parseYemotResponse = (responseBody) => {
             parsedData.hangup = true;
         }
     }
-    
+
     return parsedData;
 };
 
+const getPromptText = (lines) => {
+    const textLines = (lines || []).filter(line => line.type === 'text');
+    return textLines.length ? textLines[textLines.length - 1].content : '';
+};
 
 // Components
 const MessageDisplay = ({ line }) => {
     if (line.type === 'file') {
         return (
-            <Chip 
+            <Chip
                 icon={<AudioFileIcon />}
                 label={line.content}
                 variant="outlined"
                 color="secondary"
                 size="small"
-                sx={{ 
+                sx={{
                     backgroundColor: '#e3f2fd',
                     borderColor: '#1976d2',
                     '& .MuiChip-label': {
@@ -99,23 +103,101 @@ const MessageDisplay = ({ line }) => {
             />
         );
     }
-    
+
     return <span>{line.content}</span>;
 };
 
-const HistoryStep = ({ lines }) => {
+const SystemMessageBubble = ({ lines }) => (
+    <Paper
+        elevation={1}
+        sx={{
+            alignSelf: 'flex-start',
+            maxWidth: '75%',
+            padding: 1.5,
+            borderRadius: 2,
+            backgroundColor: '#f8f9fa',
+            borderRight: '3px solid #1976d2',
+        }}
+    >
+        {lines.map((line, index) => (
+            <div key={index} style={{ marginBottom: index < lines.length - 1 ? '4px' : 0 }}>
+                <MessageDisplay line={line} />
+            </div>
+        ))}
+    </Paper>
+);
+
+const UserAnswerBubble = ({ answer }) => (
+    <Paper
+        elevation={0}
+        sx={{
+            alignSelf: 'flex-end',
+            maxWidth: '75%',
+            padding: 1,
+            borderRadius: 2,
+            backgroundColor: '#e8f5e8',
+            color: '#2e7d32',
+            fontWeight: 600,
+        }}
+    >
+        {answer}
+    </Paper>
+);
+
+const TranscriptStep = ({ step }) => (
+    <>
+        <SystemMessageBubble lines={step.prompt} />
+        {step.answer && <UserAnswerBubble answer={step.answer} />}
+    </>
+);
+
+const ConversationTranscript = ({ history }) => {
+    const bottomRef = useRef(null);
+
+    useEffect(() => {
+        bottomRef.current?.scrollIntoView({ block: 'nearest' });
+    }, [history.length]);
+
+    if (!history.length) {
+        return null;
+    }
+
     return (
-        <Box sx={{ marginY: 1, padding: 1, backgroundColor: '#f5f5f5', borderRadius: 1 }}>
-            {lines.map((line, index) => (
-                <div key={index} style={{ marginBottom: '4px' }}>
-                    <MessageDisplay line={line} />
-                </div>
+        <Box
+            sx={{
+                width: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 1.5,
+                maxHeight: '50vh',
+                overflowY: 'auto',
+                padding: 1,
+                marginY: 1,
+            }}
+        >
+            {history.map((step, index) => (
+                <TranscriptStep key={index} step={step} />
             ))}
+            <div ref={bottomRef} />
         </Box>
     );
 };
 
-const HangupButton = ({ params, isHangup, handleSubmit, ...props }) => {
+const CallSetupSummary = ({ values }) => {
+    if (!values) return null;
+
+    return (
+        <Box sx={{ width: '100%', display: 'flex', gap: 1, flexWrap: 'wrap', marginBottom: 1 }}>
+            <Chip size="small" variant="outlined" label={`מספר מערכת: ${values.ApiDID}`} />
+            <Chip size="small" variant="outlined" label={`מאת: ${values.ApiPhone}`} />
+            {values.ApiEnterID && (
+                <Chip size="small" variant="outlined" label={`מספר זיהוי: ${values.ApiEnterID}`} />
+            )}
+        </Box>
+    );
+};
+
+const HangupButton = ({ params, phase, handleSubmit, ...props }) => {
     const form = useFormContext();
 
     const handleClick = useCallback(() => {
@@ -123,73 +205,104 @@ const HangupButton = ({ params, isHangup, handleSubmit, ...props }) => {
     }, [form]);
 
     useEffect(() => {
-        if (isHangup) {
+        if (phase === 'hangup') {
             form.setValue('hangup', 'yes');
             form.handleSubmit(handleSubmit);
         }
-    }, [isHangup, form, handleSubmit]);
+    }, [phase, form, handleSubmit]);
 
-    if (isHangup) {
+    if (phase === 'hangup') {
         return null;
     }
 
     return (
-        <SaveButton 
-            onClick={handleClick} 
-            label={'ra.action.hangup'} 
-            icon={<CallEndIcon />} 
-            disabled={!params.length} 
-            {...props} 
+        <SaveButton
+            onClick={handleClick}
+            label={'ra.action.hangup'}
+            icon={<CallEndIcon />}
+            disabled={!params.length}
+            {...props}
         />
     );
 };
 
-const SimulatorToolbar = ({ isHangup, params, handleSubmit, handleReload }) => (
+const NewCallButton = ({ onNewCall, ...props }) => {
+    const form = useFormContext();
+
+    const handleClick = useCallback(() => {
+        form.reset({ ...DEFAULT_VALUES, ApiCallId: String(Math.random()).slice(2) });
+        onNewCall();
+    }, [form, onNewCall]);
+
+    return (
+        <RefreshButton
+            onClick={handleClick}
+            label="ra.yemot_simulator.new_call"
+            sx={{ marginInline: '1rem' }}
+            size='medium'
+            {...props}
+        />
+    );
+};
+
+const SimulatorToolbar = ({ phase, params, handleSubmit, onNewCall }) => (
     <Toolbar>
-        <SaveButton disabled={isHangup} alwaysEnable={true} />
-        <RefreshButton onClick={handleReload} sx={{ marginInline: '1rem' }} size='medium' />
-        <HangupButton 
-            params={params} 
-            isHangup={isHangup} 
-            handleSubmit={handleSubmit} 
-            alwaysEnable={true} 
-            formNoValidate 
+        <SaveButton
+            label={phase === 'setup' ? 'ra.yemot_simulator.start_call' : 'ra.yemot_simulator.send'}
+            disabled={phase === 'hangup'}
+            alwaysEnable={true}
+        />
+        <NewCallButton onNewCall={onNewCall} />
+        <HangupButton
+            params={params}
+            phase={phase}
+            handleSubmit={handleSubmit}
+            alwaysEnable={true}
+            formNoValidate
         />
     </Toolbar>
 );
 
-const CallInputs = ({ params, isHangup }) => (
+const CallInputs = ({ phase, params, activeLabel }) => (
     <>
-        <TextInput source="ApiCallId" label="מזהה שיחה" validate={required()} readOnly />
-        <TextInput source="ApiExtension" label="שלוחה" validate={required()} readOnly />
-        <TextInput source="ApiDID" label="מספר מערכת" validate={required()} />
-        <TextInput source="ApiPhone" label="מאת מס׳ טלפון" validate={required()} />
-        <TextInput source="ApiEnterID" label="מספר זיהוי" />
-        {params.map(param => (
-            <TextInput 
-                source={param} 
-                key={param} 
-                validate={required()} 
-                disabled={isHangup} 
+        <TextInput source="ApiCallId" validate={required()} readOnly sx={{ display: 'none' }} />
+        <TextInput source="ApiExtension" validate={required()} readOnly sx={{ display: 'none' }} />
+        <TextInput
+            source="ApiDID"
+            label="מספר מערכת"
+            validate={required()}
+            sx={{ display: phase === 'setup' ? undefined : 'none' }}
+        />
+        <TextInput
+            source="ApiPhone"
+            label="מאת מס׳ טלפון"
+            validate={required()}
+            sx={{ display: phase === 'setup' ? undefined : 'none' }}
+        />
+        <TextInput
+            source="ApiEnterID"
+            label="מספר זיהוי"
+            sx={{ display: phase === 'setup' ? undefined : 'none' }}
+        />
+        {phase === 'in-call' && params.map(param => (
+            <TextInput
+                source={param}
+                key={param}
+                label={activeLabel || undefined}
+                validate={required()}
             />
         ))}
     </>
 );
 
-const CallHistory = ({ history }) => (
-    <>
-        {history.map((item, index) => (
-            <HistoryStep key={index} lines={item} />
-        ))}
-    </>
-);
+const HangupMessage = ({ phase }) => {
+    const translate = useTranslate();
 
-const HangupMessage = ({ isHangup }) => {
-    if (!isHangup) return null;
-    
+    if (phase !== 'hangup') return null;
+
     return (
         <Box sx={{ marginY: 2, padding: 2, backgroundColor: '#ffebee', borderRadius: 1, textAlign: 'center' }}>
-            השיחה נותקה, אפשר לרענן בשביל להתחיל שיחה חדשה
+            <Typography>{translate('ra.yemot_simulator.hangup_message')}</Typography>
         </Box>
     );
 };
@@ -199,24 +312,34 @@ const YemotSimulator = () => {
     const dataProvider = useDataProvider();
     const [history, setHistory] = useState([]);
     const [params, setParams] = useState([]);
-    const [isHangup, setIsHangup] = useState(false);
+    const [phase, setPhase] = useState('setup');
+    const [setupValues, setSetupValues] = useState(null);
     const notify = useNotify();
 
-    const { mutate, isPending } = useMutation({
+    const { mutate } = useMutation({
         mutationFn: (body) => dataProvider.simulateYemotCall(body),
-        onSuccess: (data) => {
+        onSuccess: (data, variables) => {
             const parsedData = parseYemotResponse(data.body);
-            
-            if (parsedData.lines.length > 0) {
-                setHistory(prevData => ([...prevData, parsedData.lines]));
+
+            if (phase === 'setup') {
+                setSetupValues({
+                    ApiDID: variables.ApiDID,
+                    ApiPhone: variables.ApiPhone,
+                    ApiEnterID: variables.ApiEnterID,
+                });
+                setPhase('in-call');
             }
-            
+
+            if (parsedData.lines.length > 0) {
+                setHistory(prevData => ([...prevData, { prompt: parsedData.lines }]));
+            }
+
             if (parsedData.param) {
-                setParams(prevData => ([parsedData.param]));
+                setParams([parsedData.param]);
             }
 
             if (parsedData.hangup) {
-                setIsHangup(true);
+                setPhase('hangup');
                 return;
             }
 
@@ -228,34 +351,51 @@ const YemotSimulator = () => {
     });
 
     const handleSubmit = useCallback((body) => {
+        setHistory(prevData => {
+            if (prevData.length === 0) {
+                return prevData;
+            }
+            const answer = params.map(param => body[param]).filter(Boolean).join(', ');
+            if (!answer) {
+                return prevData;
+            }
+            const updated = [...prevData];
+            updated[updated.length - 1] = { ...updated[updated.length - 1], answer };
+            return updated;
+        });
         mutate(body);
-    }, [mutate]);
+    }, [mutate, params]);
 
-    const handleReload = useCallback(() => {
-        window.location.reload();
+    const handleNewCall = useCallback(() => {
+        setHistory([]);
+        setParams([]);
+        setPhase('setup');
+        setSetupValues(null);
     }, []);
 
-    // todo: autofill user phone
+    const activeLabel = history.length ? getPromptText(history[history.length - 1].prompt) : '';
+
     return (
         <Card>
             <Title title="סימולטור" />
             <CardContent>
-                <SimpleForm 
-                    onSubmit={handleSubmit} 
-                    defaultValues={DEFAULT_VALUES} 
+                <SimpleForm
+                    onSubmit={handleSubmit}
+                    defaultValues={DEFAULT_VALUES}
                     toolbar={
-                        <SimulatorToolbar 
-                            isHangup={isHangup}
+                        <SimulatorToolbar
+                            phase={phase}
                             params={params}
                             handleSubmit={handleSubmit}
-                            handleReload={handleReload}
+                            onNewCall={handleNewCall}
                         />
                     }
                 >
-                    <CallInputs params={params} isHangup={isHangup} />
+                    <CallSetupSummary values={phase !== 'setup' ? setupValues : null} />
+                    <ConversationTranscript history={history} />
+                    <CallInputs phase={phase} params={params} activeLabel={activeLabel} />
                 </SimpleForm>
-                <CallHistory history={history} />
-                <HangupMessage isHangup={isHangup} />
+                <HangupMessage phase={phase} />
             </CardContent>
         </Card>
     );

--- a/providers/i18nProvider.js
+++ b/providers/i18nProvider.js
@@ -151,6 +151,10 @@ const extendedTranslation = {
         },
         yemot_simulator: {
             step_success: 'התקבל בהצלחה, אפשר להמשיך בתהליך',
+            start_call: 'התחל שיחה',
+            send: 'שליחה',
+            new_call: 'שיחה חדשה',
+            hangup_message: 'השיחה נותקה, אפשר להתחיל שיחה חדשה',
         }
     }
 }

--- a/providers/i18nProvider.js
+++ b/providers/i18nProvider.js
@@ -155,6 +155,7 @@ const extendedTranslation = {
             send: 'שליחה',
             new_call: 'שיחה חדשה',
             hangup_message: 'השיחה נותקה, אפשר להתחיל שיחה חדשה',
+            answer_label: 'תשובה',
         }
     }
 }


### PR DESCRIPTION
Replace the always-visible flat form with a phase-driven flow: setup fields collapse into a summary once the call starts, system prompts and the developer's answers render as chat bubbles, and the active input is labeled with the actual prompt text instead of the internal param key. Reset now happens in place via form.reset() instead of a full page reload.