### PR TITLE
feat: add CommonPhoneResources shared component

### DIFF
--- a/components/app/CommonPhoneResources.jsx
+++ b/components/app/CommonPhoneResources.jsx
@@ -1,0 +1,34 @@
+import { Resource } from 'react-admin';
+import phoneCampaign from '@shared/components/common-entities/phone-campaign';
+import phoneTemplate from '@shared/components/common-entities/phone-template';
+import PhoneIcon from '@mui/icons-material/Phone';
+import DescriptionIcon from '@mui/icons-material/Description';
+import { isPhoneCampaign } from '@shared/utils/permissionsUtil';
+
+/**
+ * Renders the phone campaign resources that are identical across all NRA apps:
+ *   phone_template  (phoneCampaign permission)
+ *   phone_campaign  (phoneCampaign permission)
+ *
+ * Props:
+ *  - permissions {*} React-Admin permissions object
+ */
+const CommonPhoneResources = ({ permissions }) =>
+  isPhoneCampaign(permissions) && (
+    <>
+      <Resource
+        name="phone_template"
+        {...phoneTemplate}
+        options={{ menuGroup: 'settings' }}
+        icon={DescriptionIcon}
+      />
+      <Resource
+        name="phone_campaign"
+        {...phoneCampaign}
+        options={{ menuGroup: 'settings' }}
+        icon={PhoneIcon}
+      />
+    </>
+  );
+
+export default CommonPhoneResources;


### PR DESCRIPTION
Extract phone_template and phone_campaign resource declarations into a reusable shared component, eliminating duplication across all NRA projects. Uses the existing 'settings' menu group and distinct icons per resource.