### PR TITLE
fix: hide Send button on hangup instead of a no-op disabled prop

### DIFF
--- a/components/views/YemotSimulator.jsx
+++ b/components/views/YemotSimulator.jsx
@@ -261,11 +261,12 @@ const NewCallButton = ({ onNewCall, ...props }) => {
 
 const SimulatorToolbar = ({ phase, params, onNewCall }) => (
     <Toolbar>
-        <SaveButton
-            label={phase === 'setup' ? 'ra.yemot_simulator.start_call' : 'ra.yemot_simulator.send'}
-            disabled={phase === 'hangup'}
-            alwaysEnable={true}
-        />
+        {phase !== 'hangup' && (
+            <SaveButton
+                label={phase === 'setup' ? 'ra.yemot_simulator.start_call' : 'ra.yemot_simulator.send'}
+                alwaysEnable={true}
+            />
+        )}
         <NewCallButton onNewCall={onNewCall} />
         <HangupButton
             params={params}


### PR DESCRIPTION
SaveButton's alwaysEnable={true} makes it ignore its own disabled prop entirely (valueOrDefault short-circuits to false), so disabled={phase === 'hangup'} never actually did anything - Send stayed active after hangup while HangupButton correctly hid itself. Align Send with the same "don't render once hung up" pattern HangupButton already uses.