### PR TITLE
feat(yemot-simulator): admin user picker for call-from phone number

### DIFF
--- a/components/views/YemotSimulator.jsx
+++ b/components/views/YemotSimulator.jsx
@@ -227,7 +227,7 @@ const UserPhoneSelector = ({ phase }) => {
                 source="selectedUserId"
                 reference="user"
                 label="מאת משתמש"
-                filter={{ 'phoneNumber||$notnull': true, 'phoneNumber||$ne': '' }}
+                filter={{ 'phoneNumber||$ne': '' }}
                 validate={required()}
                 sx={{ flexGrow: 1 }}
             />

--- a/components/views/YemotSimulator.jsx
+++ b/components/views/YemotSimulator.jsx
@@ -1,10 +1,12 @@
 import { Card, CardContent, Chip, Box, Paper, Typography } from '@mui/material';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { SimpleForm, TextInput, Title, useDataProvider, useGetIdentity, useNotify, useTranslate, Toolbar, SaveButton, RefreshButton } from 'react-admin';
+import { SimpleForm, TextInput, Title, useDataProvider, useGetIdentity, useGetOne, useNotify, useTranslate, Toolbar, SaveButton, RefreshButton } from 'react-admin';
 import { useMutation } from '@tanstack/react-query';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import CallEndIcon from '@mui/icons-material/CallEnd'
 import AudioFileIcon from '@mui/icons-material/AudioFile'
+import CommonReferenceInput from '@shared/components/fields/CommonReferenceInput';
+import { useIsAdmin } from '@shared/utils/permissionsUtil';
 
 // Constants
 const DEFAULT_VALUES = {
@@ -183,20 +185,57 @@ const ConversationTranscript = ({ history }) => {
     );
 };
 
-const PhonePrefill = ({ phase }) => {
+const PhonePrefill = ({ phase, isAdmin }) => {
     const { identity } = useGetIdentity();
     const form = useFormContext();
 
     useEffect(() => {
-        if (phase !== 'setup' || !identity?.phoneNumber) {
+        if (isAdmin || phase !== 'setup' || !identity?.phoneNumber) {
             return;
         }
         if (!form.getValues('ApiPhone')) {
             form.setValue('ApiPhone', identity.phoneNumber);
         }
-    }, [phase, identity?.phoneNumber, form]);
+    }, [isAdmin, phase, identity?.phoneNumber, form]);
 
     return null;
+};
+
+const UserPhoneSelector = ({ phase }) => {
+    const form = useFormContext();
+    const selectedUserId = useWatch({ name: 'selectedUserId' });
+    const { data: selectedUser } = useGetOne(
+        'user',
+        { id: selectedUserId },
+        { enabled: !!selectedUserId }
+    );
+
+    useEffect(() => {
+        form.setValue('ApiPhone', selectedUser?.phoneNumber || '');
+    }, [selectedUser, form]);
+
+    return (
+        <Box
+            sx={{
+                display: phase === 'setup' ? 'flex' : 'none',
+                alignItems: 'center',
+                gap: 1,
+                width: '100%',
+            }}
+        >
+            <CommonReferenceInput
+                source="selectedUserId"
+                reference="user"
+                label="מאת משתמש"
+                filter={{ 'phoneNumber||$notnull': true, 'phoneNumber||$ne': '' }}
+                validate={required()}
+                sx={{ flexGrow: 1 }}
+            />
+            {selectedUser?.phoneNumber && (
+                <Chip label={selectedUser.phoneNumber} size="small" variant="outlined" />
+            )}
+        </Box>
+    );
 };
 
 const CallSetupSummary = ({ values }) => {
@@ -235,7 +274,7 @@ const HangupButton = ({ params, phase, ...props }) => {
     );
 };
 
-const NewCallButton = ({ onNewCall, ...props }) => {
+const NewCallButton = ({ onNewCall, isAdmin, ...props }) => {
     const { identity } = useGetIdentity();
     const form = useFormContext();
 
@@ -243,10 +282,11 @@ const NewCallButton = ({ onNewCall, ...props }) => {
         form.reset({
             ...DEFAULT_VALUES,
             ApiCallId: String(Math.random()).slice(2),
-            ApiPhone: identity?.phoneNumber || DEFAULT_VALUES.ApiPhone,
+            ApiPhone: !isAdmin && identity?.phoneNumber ? identity.phoneNumber : DEFAULT_VALUES.ApiPhone,
+            selectedUserId: null,
         });
         onNewCall();
-    }, [form, identity?.phoneNumber, onNewCall]);
+    }, [form, isAdmin, identity?.phoneNumber, onNewCall]);
 
     return (
         <RefreshButton
@@ -259,7 +299,7 @@ const NewCallButton = ({ onNewCall, ...props }) => {
     );
 };
 
-const SimulatorToolbar = ({ phase, params, onNewCall }) => (
+const SimulatorToolbar = ({ phase, params, onNewCall, isAdmin }) => (
     <Toolbar>
         {phase !== 'hangup' && (
             <SaveButton
@@ -267,7 +307,7 @@ const SimulatorToolbar = ({ phase, params, onNewCall }) => (
                 alwaysEnable={true}
             />
         )}
-        <NewCallButton onNewCall={onNewCall} />
+        <NewCallButton onNewCall={onNewCall} isAdmin={isAdmin} />
         <HangupButton
             params={params}
             phase={phase}
@@ -277,7 +317,7 @@ const SimulatorToolbar = ({ phase, params, onNewCall }) => (
     </Toolbar>
 );
 
-const CallInputs = ({ phase, params, activeLabel }) => {
+const CallInputs = ({ phase, params, activeLabel, isAdmin }) => {
     const translate = useTranslate();
 
     return (
@@ -290,12 +330,8 @@ const CallInputs = ({ phase, params, activeLabel }) => {
                 validate={required()}
                 sx={{ display: phase === 'setup' ? undefined : 'none' }}
             />
-            <TextInput
-                source="ApiPhone"
-                label="מאת מס׳ טלפון"
-                validate={required()}
-                sx={{ display: phase === 'setup' ? undefined : 'none' }}
-            />
+            <TextInput source="ApiPhone" validate={required()} readOnly sx={{ display: 'none' }} />
+            {isAdmin && <UserPhoneSelector phase={phase} />}
             <TextInput
                 source="ApiEnterID"
                 label="מספר זיהוי"
@@ -325,10 +361,21 @@ const HangupMessage = ({ phase }) => {
     );
 };
 
+const NoPhoneMessage = () => {
+    const translate = useTranslate();
+
+    return (
+        <Box sx={{ padding: 2, textAlign: 'center' }}>
+            <Typography>{translate('ra.yemot_simulator.no_phone_message')}</Typography>
+        </Box>
+    );
+};
+
 // Main Component
 const YemotSimulator = () => {
     const dataProvider = useDataProvider();
-    const { identity } = useGetIdentity();
+    const { identity, isPending: identityLoading } = useGetIdentity();
+    const isAdmin = useIsAdmin();
     const [history, setHistory] = useState([]);
     const [params, setParams] = useState([]);
     const [phase, setPhase] = useState('setup');
@@ -405,30 +452,38 @@ const YemotSimulator = () => {
     const activeLabel = history.length ? getPromptText(history[history.length - 1].prompt) : '';
     const initialDefaultValues = {
         ...DEFAULT_VALUES,
-        ApiPhone: identity?.phoneNumber || DEFAULT_VALUES.ApiPhone,
+        ApiPhone: !isAdmin && identity?.phoneNumber ? identity.phoneNumber : DEFAULT_VALUES.ApiPhone,
     };
+    const canUseSimulator = isAdmin || !!identity?.phoneNumber;
 
     return (
         <Card>
             <Title title="סימולטור" />
             <CardContent>
-                <SimpleForm
-                    onSubmit={handleSubmit}
-                    defaultValues={initialDefaultValues}
-                    toolbar={
-                        <SimulatorToolbar
-                            phase={phase}
-                            params={params}
-                            onNewCall={handleNewCall}
-                        />
-                    }
-                >
-                    <PhonePrefill phase={phase} />
-                    <CallSetupSummary values={phase !== 'setup' ? setupValues : null} />
-                    <ConversationTranscript history={history} />
-                    <CallInputs phase={phase} params={params} activeLabel={activeLabel} />
-                </SimpleForm>
-                <HangupMessage phase={phase} />
+                {!identityLoading && !canUseSimulator ? (
+                    <NoPhoneMessage />
+                ) : (
+                    <>
+                        <SimpleForm
+                            onSubmit={handleSubmit}
+                            defaultValues={initialDefaultValues}
+                            toolbar={
+                                <SimulatorToolbar
+                                    phase={phase}
+                                    params={params}
+                                    onNewCall={handleNewCall}
+                                    isAdmin={isAdmin}
+                                />
+                            }
+                        >
+                            <PhonePrefill phase={phase} isAdmin={isAdmin} />
+                            <CallSetupSummary values={phase !== 'setup' ? setupValues : null} />
+                            <ConversationTranscript history={history} />
+                            <CallInputs phase={phase} params={params} activeLabel={activeLabel} isAdmin={isAdmin} />
+                        </SimpleForm>
+                        <HangupMessage phase={phase} />
+                    </>
+                )}
             </CardContent>
         </Card>
     );

--- a/providers/i18nProvider.js
+++ b/providers/i18nProvider.js
@@ -156,6 +156,7 @@ const extendedTranslation = {
             new_call: 'שיחה חדשה',
             hangup_message: 'השיחה נותקה, אפשר להתחיל שיחה חדשה',
             answer_label: 'תשובה',
+            no_phone_message: 'יש להגדיר מספר טלפון בהגדרות המשתמש כדי להשתמש בסימולטור',
         }
     }
 }


### PR DESCRIPTION
Admins get a searchable dropdown of users (filtered to those with a phone number set) instead of typing a phone number, with the selected user's number shown as a read-only chip. Non-admin users no longer see a phone number field at all — it's silently filled from their own identity. Either way, if there's no phone number to use, the simulator is blocked with an explanatory message instead of showing the form.