### PR TITLE
Fix parameter parsing in Yemot read lines with embedded equals signs

### DIFF
--- a/components/views/YemotSimulator.jsx
+++ b/components/views/YemotSimulator.jsx
@@ -18,25 +18,35 @@ const DEFAULT_VALUES = {
 };
 
 const REGEX_PATTERNS = {
-    TEXT: /[=.]t-([^=.]*)/g,
-    FILE: /[=.]f-([^=.]*)/g,
-    PARAM: /read=t-[^=]*=([^,\.]*)/
+    TEXT: /[=.]t-((?:(?!\.[tf]-|=[tf]-)[\s\S])*)/g,
+    FILE: /[=.]f-((?:(?!\.[tf]-|=[tf]-)[\s\S])*)/g,
 };
 
 // Utility Functions
 const required = (message = 'ra.validation.required') =>
     (value, allValues) => (value || allValues.hangup) ? undefined : message;
 
+// A "read" line is `read=<message>=<param>,<flag1>,<flag2>,...` (see server's getReadDef).
+// The message itself may legitimately contain "=" (e.g. embedded "[[KEY=VALUE]]" markup in
+// the read-aloud text), so the only reliable boundary is the *last* "=" in the line.
+const stripTrailingParamDef = (line) => {
+    if (line.startsWith('read') && (line.split('=').length - 1) >= 2) {
+        return line.slice(0, line.lastIndexOf('='));
+    }
+    return line;
+};
+
 export const parseResponseLine = (line) => {
     const messages = [];
+    const content = stripTrailingParamDef(line);
 
     // Collect all text messages (a single line may contain multiple =t- segments)
-    for (const match of line.matchAll(REGEX_PATTERNS.TEXT)) {
+    for (const match of content.matchAll(REGEX_PATTERNS.TEXT)) {
         messages.push({ type: 'text', content: match[1] });
     }
 
     // Collect all file messages
-    for (const match of line.matchAll(REGEX_PATTERNS.FILE)) {
+    for (const match of content.matchAll(REGEX_PATTERNS.FILE)) {
         messages.push({ type: 'file', content: match[1] });
     }
 
@@ -45,10 +55,10 @@ export const parseResponseLine = (line) => {
 
 const parseParameterFromLine = (line) => {
     if (line.startsWith('read')) {
-        const paramMatch = REGEX_PATTERNS.PARAM.exec(line);
-        if (paramMatch) {
-            const [, param] = paramMatch;
-            return param;
+        const lastEquals = line.lastIndexOf('=');
+        if (lastEquals !== -1) {
+            const [param] = line.slice(lastEquals + 1).split(',');
+            return param || null;
         }
     }
     return null;

--- a/components/views/__tests__/YemotSimulator.test.js
+++ b/components/views/__tests__/YemotSimulator.test.js
@@ -136,4 +136,16 @@ describe('parseYemotResponse', () => {
     ]);
     expect(result.param).toBe('val_1');
   });
+
+  it('resolves the param correctly when message text contains embedded "=" (e.g. [[KEY=VALUE]] markup)', () => {
+    const body = 'read=t-[[SEGMENT_ID=SEG_3B]].t-[[TITLE=רמה 3  מקטע ב2  בית הכנסת החורבה]].t-דלת בית הכנסת החורבה פתוחה=val_3,no,1,1,7,No,no,no,,,,,None,';
+    const result = parseYemotResponse(body);
+    expect(result.lines).toEqual([
+      { type: 'text', content: '[[SEGMENT_ID=SEG_3B]]' },
+      { type: 'text', content: '[[TITLE=רמה 3  מקטע ב2  בית הכנסת החורבה]]' },
+      { type: 'text', content: 'דלת בית הכנסת החורבה פתוחה' },
+    ]);
+    expect(result.param).toBe('val_3');
+    expect(result.hangup).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
Fixed a bug in the Yemot simulator where parameter extraction from `read` lines failed when the message text contained embedded equals signs (e.g., `[[KEY=VALUE]]` markup). The previous regex-based approach couldn't distinguish between equals signs in the message content versus the delimiter between message and parameters.

## Key Changes
- **Improved regex patterns**: Updated `TEXT` and `FILE` regex patterns to use negative lookahead assertions, preventing them from matching across parameter boundaries (lines starting with `.t-`, `.f-`, `=t-`, or `=f-`)
- **New utility function**: Added `stripTrailingParamDef()` to reliably extract the message portion by finding the last equals sign in `read` lines (the only reliable boundary since messages can contain `=`)
- **Refactored parameter parsing**: Replaced regex-based `REGEX_PATTERNS.PARAM` with a simpler approach using `lastIndexOf('=')` to locate the parameter section
- **Added test coverage**: New test case validates correct parsing of a real-world example with Hebrew text and embedded `[[KEY=VALUE]]` markup

## Implementation Details
The fix leverages the server's `read` line format: `read=<message>=<param>,<flag1>,<flag2>,...`. Since the message itself may contain `=` characters, the parameter section is reliably identified as everything after the *last* `=` in the line. This approach is more robust than regex matching and handles arbitrary message content.

https://claude.ai/code/session_014vvwdfGgFNMeo14pNLpxrX