### PR TITLE
fix(yemot-simulator): hide ApiDID field, show ApiPhone instead

### DIFF
--- a/components/views/YemotSimulator.jsx
+++ b/components/views/YemotSimulator.jsx
@@ -334,13 +334,13 @@ const CallInputs = ({ phase, params, activeLabel, isAdmin }) => {
         <>
             <TextInput source="ApiCallId" validate={required()} readOnly sx={{ display: 'none' }} />
             <TextInput source="ApiExtension" validate={required()} readOnly sx={{ display: 'none' }} />
+            <TextInput source="ApiDID" validate={required()} readOnly sx={{ display: 'none' }} />
             <TextInput
-                source="ApiDID"
+                source="ApiPhone"
                 label="מספר מערכת"
                 validate={required()}
                 sx={{ display: phase === 'setup' ? undefined : 'none' }}
             />
-            <TextInput source="ApiPhone" validate={required()} readOnly sx={{ display: 'none' }} />
             {isAdmin && <UserPhoneSelector phase={phase} />}
             <TextInput
                 source="ApiEnterID"

--- a/components/views/__tests__/YemotSimulatorPrefill.test.jsx
+++ b/components/views/__tests__/YemotSimulatorPrefill.test.jsx
@@ -12,7 +12,7 @@ import YemotSimulator from '../YemotSimulator';
  * number must therefore prefill ApiDID, otherwise they have to type it in
  * manually on every call.
  *
- * ApiPhone (hidden, but a required field) must also still end up populated
+ * ApiDID (hidden, but a required field) must also still end up populated
  * once identity resolves, otherwise the form can't be submitted.
  */
 describe('YemotSimulator setup prefill', () => {
@@ -23,7 +23,7 @@ describe('YemotSimulator setup prefill', () => {
         checkError: () => Promise.resolve(),
     };
 
-    it('prefills the system number (ApiDID) field with the user\'s own phone number', async () => {
+    it('prefills the system number (ApiPhone) field with the user\'s own phone number', async () => {
         const dataProvider = testDataProvider();
         const { container } = render(
             <TestMemoryRouter initialEntries={['/yemot-simulator']}>
@@ -36,7 +36,7 @@ describe('YemotSimulator setup prefill', () => {
         const systemNumberInput = await screen.findByLabelText('מספר מערכת');
         await waitFor(() => expect(systemNumberInput).toHaveValue('0501234567'));
 
-        const apiPhoneInput = container.querySelector('input[name="ApiPhone"]');
-        await waitFor(() => expect(apiPhoneInput).toHaveValue('0501234567'));
+        const apiDidInput = container.querySelector('input[name="ApiDID"]');
+        await waitFor(() => expect(apiDidInput).toHaveValue('0501234567'));
     });
 });

--- a/components/views/__tests__/YemotSimulatorUserPhoneSelector.test.jsx
+++ b/components/views/__tests__/YemotSimulatorUserPhoneSelector.test.jsx
@@ -19,37 +19,37 @@ import YemotSimulator from '../YemotSimulator';
  * 400 "Invalid filter value".
  */
 describe('YemotSimulator admin user selector', () => {
-    const authProvider = {
-        checkAuth: () => Promise.resolve(),
-        getIdentity: () => Promise.resolve({ id: 1 }),
-        getPermissions: () => Promise.resolve({ admin: true }),
-        checkError: () => Promise.resolve(),
-    };
+  const authProvider = {
+    checkAuth: () => Promise.resolve(),
+    getIdentity: () => Promise.resolve({ id: 1 }),
+    getPermissions: () => Promise.resolve({ admin: true }),
+    checkError: () => Promise.resolve(),
+  };
 
-    const user = { id: 7, name: 'Test User', phoneNumber: '0521112222' };
+  const user = { id: 7, name: 'Test User', phoneNumber: '0521112222' };
 
-    it('prefills ApiDID and ApiPhone with the selected user\'s phone number', async () => {
-        const dataProvider = testDataProvider({
-            getList: () => Promise.resolve({ data: [user], total: 1 }),
-            getOne: () => Promise.resolve({ data: user }),
-        });
-        const { container } = render(
-            <TestMemoryRouter initialEntries={['/yemot-simulator']}>
-                <AdminContext dataProvider={dataProvider} authProvider={authProvider}>
-                    <YemotSimulator />
-                </AdminContext>
-            </TestMemoryRouter>
-        );
-
-        const selector = await screen.findByLabelText('מאת משתמש');
-        await userEvent.type(selector, 'Test');
-        const option = await screen.findByText('Test User');
-        await userEvent.click(option);
-
-        const apiDidInput = await screen.findByLabelText('מספר מערכת');
-        await waitFor(() => expect(apiDidInput).toHaveValue('0521112222'));
-
-        const apiPhoneInput = container.querySelector('input[name="ApiPhone"]');
-        await waitFor(() => expect(apiPhoneInput).toHaveValue('0521112222'));
+  it('prefills ApiDID and ApiPhone with the selected user\'s phone number', async () => {
+    const dataProvider = testDataProvider({
+      getList: () => Promise.resolve({ data: [user], total: 1 }),
+      getOne: () => Promise.resolve({ data: user }),
     });
+    const { container } = render(
+      <TestMemoryRouter initialEntries={['/yemot-simulator']}>
+        <AdminContext dataProvider={dataProvider} authProvider={authProvider}>
+          <YemotSimulator />
+        </AdminContext>
+      </TestMemoryRouter>
+    );
+
+    const selector = await screen.findByLabelText('מאת משתמש');
+    await userEvent.type(selector, 'Test');
+    const option = await screen.findByText('Test User');
+    await userEvent.click(option);
+
+    const apiDidInput = await screen.findByLabelText('מספר מערכת');
+    await waitFor(() => expect(apiDidInput).toHaveValue('0521112222'));
+
+    const apiPhoneInput = container.querySelector('input[name="ApiPhone"]');
+    await waitFor(() => expect(apiPhoneInput).toHaveValue('0521112222'));
+  });
 });


### PR DESCRIPTION
Swaps which of the two same-valued setup fields is visible: ApiDID is now hidden/readOnly, and ApiPhone is the visible field labeled 'מספר מערכת'. Both fields continue to be kept in sync by PhonePrefill (non-admin) and UserPhoneSelector (admin).

Updated the two prefill regression tests to query the correct field names for the now-hidden vs now-visible inputs. Full client suite passing (22 suites / 149 tests).