### PR TITLE
Add phone number settings input

### DIFF
--- a/components/phone/PhoneSettingsInput.jsx
+++ b/components/phone/PhoneSettingsInput.jsx
@@ -1,0 +1,34 @@
+import { Accordion, AccordionDetails, AccordionSummary, Typography } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { TextInput, maxLength, useGetIdentity } from 'react-admin';
+
+/**
+ * Settings accordion section for updating the user's phone number.
+ *
+ * Usage: render inside a react-admin SimpleForm on the user settings page.
+ * The form field name is `phoneNumber`, saved via dataProvider.updateProfile.
+ *
+ * @example
+ * <SimpleForm>
+ *   <PhoneSettingsInput />
+ * </SimpleForm>
+ */
+export const PhoneSettingsInput = () => {
+    const { identity } = useGetIdentity();
+    return (
+        <Accordion sx={{ width: '100%' }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Typography variant="h6">מספר טלפון</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+                <TextInput
+                    source="phoneNumber"
+                    label="resources.settings.fields.phoneNumber"
+                    fullWidth
+                    validate={maxLength(11)}
+                    defaultValue={identity?.phoneNumber ?? ''}
+                />
+            </AccordionDetails>
+        </Accordion>
+    );
+};

--- a/entities/shared-entity.translations.js
+++ b/entities/shared-entity.translations.js
@@ -199,6 +199,7 @@ export const sharedEntityTranslations = {
   settings: {
     fields: {
       yemotApiKey: 'מפתח API של Yemot',
+      phoneNumber: 'מספר טלפון',
     },
   },
 };

--- a/providers/__tests__/dataProvider.test.js
+++ b/providers/__tests__/dataProvider.test.js
@@ -122,6 +122,24 @@ describe('dataProvider', () => {
     });
   });
 
+  describe('updateProfile', () => {
+    it('updates profile', async () => {
+      const profile = { phoneNumber: '0501234567' };
+      fetchJson.mockResolvedValueOnce({ json: { success: true } });
+
+      await dataProvider.updateProfile({ data: profile });
+
+      // Use expect.stringMatching to handle potential trailing slash
+      expect(fetchJson).toHaveBeenCalledWith(
+        expect.stringMatching(new RegExp(`${apiUrl}/profile/?$`)),
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify(profile),
+        })
+      );
+    });
+  });
+
   describe('action', () => {
     it('executes action with query params and body', async () => {
       const queryParams = { filter: 'active' };

--- a/providers/dataProvider.js
+++ b/providers/dataProvider.js
@@ -41,6 +41,12 @@ dataProvider.updateSettings = async ({ data }) =>
         body: JSON.stringify(data)
     });
 
+dataProvider.updateProfile = async ({ data }) =>
+    dataProvider.exec('profile', '', {
+        method: 'PATCH',
+        body: JSON.stringify(data)
+    });
+
 const createQueryParamsStrWithAction = (queryParams, action) => {
     return new URLSearchParams({
         ...queryParams,


### PR DESCRIPTION
## Summary
- Add `dataProvider.updateProfile({ data })`, which calls the new `PATCH /profile` endpoint (companion server-side PR in buzz-code/nra-server), separate from the existing `updateSettings` which only persists to `additionalData`.
- Add `PhoneSettingsInput.jsx`, a settings-page accordion for editing `phoneNumber`, mirroring the existing `YemotSettingsInput.jsx` pattern. Reads the current value from `useGetIdentity()` and validates with the same `maxLength(11)` rule already used on the admin user form.
- Add the `resources.settings.fields.phoneNumber` translation key.

This component isn't wired into any app's Settings page yet — each app (react-admin-nestjs, student-report-nra, event-management-nra, dnd-management-nra, teacher-report-nra) has its own local `client/src/settings/Settings.jsx` that will need `PhoneSettingsInput` imported and its save handler updated to call `dataProvider.updateProfile` for the phone number field.

## Test plan
- [x] Added a unit test for `dataProvider.updateProfile`


---
_Generated by [Claude Code](https://claude.ai/code/session_01PZvK3iL37dFBsmNcdHfkDy)_