### PR TITLE
docs: track CommonPhoneResources as a required consumer change

### DIFF
--- a/CONSUMER_CHANGES.md
+++ b/CONSUMER_CHANGES.md
@@ -7,3 +7,4 @@ submodule bump — each needs a matching change in the consuming app.
 |---|---|---|---|
 | `54dade9` | `yemotSimulator` permission | Guard the yemot-simulator menu item with `isYemotSimulator(permissions)` instead of `isAdmin` | dnd-management-nra, react-admin-nestjs |
 | `897ec6b` | `PhoneSettingsInput` + `dataProvider.updateProfile` | Wire `PhoneSettingsInput` into `Settings.jsx`, call `updateProfile` in `handleSave` | react-admin-nestjs |
+| `19336e2` | `CommonPhoneResources` shared component | Replace any inline `phone_template`/`phone_campaign` `<Resource>` JSX with `{CommonPhoneResources({ permissions })}` | react-admin-nestjs, event-management-nra, teacher-report-nra, student-report-nra, dnd-management-nra |


### PR DESCRIPTION
## Summary
- Commit `19336e2` added `CommonPhoneResources` but was never logged in `CONSUMER_CHANGES.md`, so consuming apps had no signal to adopt it.
- This is why several apps drifted into hand-rolling `phone_template`/`phone_campaign` `<Resource>` JSX with a `menuGroup: 'phone'` that doesn't exist in any app's `menuGroups`, causing those items to render as ungrouped top-level menu entries instead of under "Settings".
- Adds the missing row to `CONSUMER_CHANGES.md` so future submodule bumps surface this required per-app action.

## Test plan
- Docs-only change to `nra-client`; no code behavior changes in this repo.
- Consumer apps (react-admin-nestjs, event-management-nra, teacher-report-nra, student-report-nra) have separately been updated on matching branches to call `CommonPhoneResources({ permissions })`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsvtBQrEGncYMKemdv5WjP)_